### PR TITLE
update syslog-ng.conf

### DIFF
--- a/syslog-ng.conf
+++ b/syslog-ng.conf
@@ -1,7 +1,8 @@
-@version: 3.9
+@version: 3.38
 
 options {
   use_dns(no);
+  dns_cache(no);
   keep_hostname(yes);
   create_dirs(yes);
   ts_format(iso);


### PR DESCRIPTION
syslog-ng.conf file isn't in sync with the installed version. This update synchronizes the version and fixes a warning.